### PR TITLE
Implement macOS compatible file system watcher

### DIFF
--- a/ArcadiaHook.cs
+++ b/ArcadiaHook.cs
@@ -56,7 +56,7 @@ namespace Arcadia
                     RT.load("arcadia/internal/config");
                     if (RT.booleanCast(Util.Invoke(RT.var("arcadia.internal.config", "get-config-key"), "reload-on-change")))
                     {
-                        var watcher = new ArcadiaWatcher();
+                        var watcher = new CrossPlatformArcadiaWatcher(false);
                     }
                 }
                 GD.Print("Arcadia loaded!");

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 * Joseph Parker - [selfsame](https://github.com/selfsame)
+* Ben Follington - [bfollington](https://github.com/bfollington)

--- a/Source/CrossPlatformArcadiaWatcher.cs
+++ b/Source/CrossPlatformArcadiaWatcher.cs
@@ -1,0 +1,109 @@
+using System.IO;
+using System.Collections.Generic;
+using System.Threading;
+using clojure.lang;
+using Godot;
+
+public class CrossPlatformArcadiaWatcher
+{
+    // Polls the FS
+    private System.Threading.Timer poll_timer;
+
+    // Reloads files
+    private System.Threading.Timer drain_timer;
+
+    private Dictionary<string, bool> changed_files = new Dictionary<string, bool>();
+    private Dictionary<string, FileInfo> _lastFiles;
+
+    private bool verbose_logging = false;
+
+    public CrossPlatformArcadiaWatcher(bool verbose)
+    {
+        this.verbose_logging = verbose;
+        poll_timer = new System.Threading.Timer(CheckStatus, new AutoResetEvent(false), 100, 100);
+        drain_timer = new System.Threading.Timer(DrainChanges, new AutoResetEvent(false), 100, 100);
+    }
+
+    private void CheckStatus(System.Object stateInfo)
+    {
+        var path = ProjectSettings.GlobalizePath("res://");
+        if (verbose_logging) { GD.Print($"Polling clj files in {path}..."); }
+        var di = new DirectoryInfo(path);
+        var files = di.GetFiles("*.clj?", SearchOption.AllDirectories);
+
+        // First time checking, nothing to compare against.
+        var lookup = new Dictionary<string, FileInfo>();
+        foreach (var fi in files)
+        {
+            var name = fi.FullName.Replace(path, "");
+            if (verbose_logging) { GD.Print("Scanning " + name); }
+            lookup.Add(name, fi);
+        }
+
+        if (_lastFiles != null)
+        {
+            foreach (var kv in lookup)
+            {
+                var name = kv.Key;
+                var fi = kv.Value;
+
+                if (_lastFiles.ContainsKey(name))
+                {
+                    var changed = fi.LastWriteTime != _lastFiles[name].LastWriteTime;
+                    if (changed)
+                    {
+                        OnChanged(name);
+                    }
+                }
+            }
+        }
+
+        _lastFiles = lookup;
+    }
+
+    private void OnChanged(string fileName)
+    {
+        GD.Print("Detected change in file " + fileName);
+        try
+        {
+            lock (changed_files)
+            {
+                changed_files[fileName] = true;
+            }
+        }
+        catch (System.Exception err)
+        {
+            GD.PrintErr(err);
+        }
+        finally
+        {
+
+        }
+    }
+
+    private void DrainChanges(System.Object stateInfo)
+    {
+        lock (changed_files)
+        {
+            foreach (var path in changed_files.Keys)
+            {
+
+                if (path != null)
+                {
+                    GD.Print("reloading ", path);
+                    try
+                    {
+                        Arcadia.Util.Invoke(RT.var("clojure.core", "load-file"), path);
+                    }
+                    catch (System.Exception e)
+                    {
+                        GD.PrintErr(e);
+                    }
+
+                }
+
+            }
+            changed_files.Clear();
+        }
+    }
+}

--- a/Source/CrossPlatformArcadiaWatcher.cs
+++ b/Source/CrossPlatformArcadiaWatcher.cs
@@ -13,7 +13,7 @@ public class CrossPlatformArcadiaWatcher
     private System.Threading.Timer drain_timer;
 
     private Dictionary<string, bool> changed_files = new Dictionary<string, bool>();
-    private Dictionary<string, FileInfo> _lastFiles;
+    private Dictionary<string, FileInfo> last_files;
 
     private bool verbose_logging = false;
 
@@ -40,16 +40,16 @@ public class CrossPlatformArcadiaWatcher
             lookup.Add(name, fi);
         }
 
-        if (_lastFiles != null)
+        if (last_files != null)
         {
             foreach (var kv in lookup)
             {
                 var name = kv.Key;
                 var fi = kv.Value;
 
-                if (_lastFiles.ContainsKey(name))
+                if (last_files.ContainsKey(name))
                 {
-                    var changed = fi.LastWriteTime != _lastFiles[name].LastWriteTime;
+                    var changed = fi.LastWriteTime != last_files[name].LastWriteTime;
                     if (changed)
                     {
                         OnChanged(name);
@@ -58,7 +58,7 @@ public class CrossPlatformArcadiaWatcher
             }
         }
 
-        _lastFiles = lookup;
+        last_files = lookup;
     }
 
     private void OnChanged(string fileName)


### PR DESCRIPTION
I use macOS as my primary OS and I was a little bummed to find out that `FileSystemWatcher` + `mono` [is completely broken on macOS](https://stackoverflow.com/questions/16519000/filesystemwatcher-under-mono-watching-subdirs). 

This is an implementation that polls the file system explicitly to detect changes in `*.clj` files which works for me on macOS Catalina, I haven't tested it on Windows but it _should_ also work there. 