### PR TITLE
Added move-and-slide function wrapper

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,2 +1,3 @@
 * Joseph Parker - [selfsame](https://github.com/selfsame)
 * Ben Follington - [bfollington](https://github.com/bfollington)
+* Arun Dilipan - [arundilipan](https://github.com/arundilipan)

--- a/Source/arcadia/2D.clj
+++ b/Source/arcadia/2D.clj
@@ -19,7 +19,7 @@
              max-slides
              floor-max-angle
              infinite-inertia?]
-      :or {floor-normal (v2)
+      :or {floor-normal (Vector2.)
            stop-on-slope? false
            max-slides 4
            floor-max-angle 0.785398

--- a/Source/arcadia/2D.clj
+++ b/Source/arcadia/2D.clj
@@ -19,7 +19,7 @@
              max-slides
              floor-max-angle
              infinite-inertia?]
-      :or {floor-normal (v2)
+      :or {floor-normal (Vector2D.)
            stop-on-slope? false
            max-slides 4
            floor-max-angle 0.785398

--- a/Source/arcadia/2D.clj
+++ b/Source/arcadia/2D.clj
@@ -1,9 +1,30 @@
 (ns arcadia.2D
   (:import 
-    [Godot Node GD Node2D Vector2]))
+    [Godot Node GD Node2D Vector2 KinematicBody2D]))
 
 (defn ^Vector2 position [^Node2D node]
   (.Position node))
 
 (defn ^Vector2 position! [^Node2D node ^Vector2 v]
   (.SetPosition node v))
+
+(defn ^Vector2 move-and-slide
+  [^KinematicBody2D o
+   ^Vector2 v
+   & {:keys [floor-normal
+             stop-on-slope?
+             max-slides
+             floor-max-angle
+             infinite-inertia?]
+      :or {floor-normal (v2)
+           stop-on-slope? false
+           max-slides 4
+           floor-max-angle 0.785398
+           infinite-inertia? true}}]
+  (.MoveAndSlide o
+                 v
+                 floor-normal
+                 stop-on-slope?
+                 max-slides
+                 floor-max-angle
+                 infinite-inertia?))

--- a/Source/arcadia/2D.clj
+++ b/Source/arcadia/2D.clj
@@ -9,6 +9,9 @@
   (.SetPosition node v))
 
 (defn ^Vector2 move-and-slide
+  "Calls the `.MoveAndSlide` method on a `KinematicBody2D`.
+   This function exists because `(.MoveAndSlide ...)` requires
+   that all C# optional parameters are provided."
   [^KinematicBody2D o
    ^Vector2 v
    & {:keys [floor-normal

--- a/Source/arcadia/3D.clj
+++ b/Source/arcadia/3D.clj
@@ -9,6 +9,9 @@
   (.SetTranslation o v))
 
 (defn ^Vector3 move-and-slide
+  "Calls the `.MoveAndSlide` method on a `KinematicBody`.
+   This function exists because `(.MoveAndSlide ...)` requires
+   that all C# optional parameters are provided."
   [^KinematicBody o
    ^Vector3 v
    & {:keys [floor-normal

--- a/Source/arcadia/3D.clj
+++ b/Source/arcadia/3D.clj
@@ -1,9 +1,30 @@
 (ns arcadia.3D
   (:import 
-    [Godot Node GD SceneTree Spatial Vector3]))
+    [Godot Node GD SceneTree Spatial Vector3 KinematicBody]))
 
 (defn ^Vector3 translation [^Spatial o]
   (.Translation o))
 
 (defn ^Vector3 translation! [^Spatial o ^Vector3 v]
   (.SetTranslation o v))
+
+(defn ^Vector3 move-and-slide
+  [^KinematicBody o
+   ^Vector3 v
+   & {:keys [floor-normal
+             stop-on-slope?
+             max-slides
+             floor-max-angle
+             infinite-inertia?]
+      :or {floor-normal (v2)
+           stop-on-slope? false
+           max-slides 4
+           floor-max-angle 0.785398
+           infinite-inertia? true}}]
+  (.MoveAndSlide o
+                 v
+                 floor-normal
+                 stop-on-slope?
+                 max-slides
+                 floor-max-angle
+                 infinite-inertia?))

--- a/Source/arcadia/3D.clj
+++ b/Source/arcadia/3D.clj
@@ -19,7 +19,7 @@
              max-slides
              floor-max-angle
              infinite-inertia?]
-      :or {floor-normal (v2)
+      :or {floor-normal (Vector3.)
            stop-on-slope? false
            max-slides 4
            floor-max-angle 0.785398


### PR DESCRIPTION
This wrapper is a convenience for not having to provide the optional C# parameters in `KinematicBody.MoveAndSlide` and `KinematicBody2D.MoveAndSlide`