### PR TITLE
Fix watcher's high CPU issue (For Linux / Windows)

### DIFF
--- a/ArcadiaHook.cs
+++ b/ArcadiaHook.cs
@@ -56,7 +56,11 @@ namespace Arcadia
                     RT.load("arcadia/internal/config");
                     if (RT.booleanCast(Util.Invoke(RT.var("arcadia.internal.config", "get-config-key"), "reload-on-change")))
                     {
-                        var watcher = new CrossPlatformArcadiaWatcher(false);
+                        if (System.Environment.OSVersion.Platform == System.PlatformID.MacOSX){
+                            var watcher = new MacOSArcadiaWatcher(false);
+                        } else {
+                            var watcher = new CrossPlatformArcadiaWatcher();
+                        }
                     }
                 }
                 GD.Print("Arcadia loaded!");
@@ -225,7 +229,7 @@ namespace Arcadia
                 catch (Exception err)
                 {
                     GD.PrintErr(err);
-                }     
+                }
             }
         }
 

--- a/Source/CrossPlatformArcadiaWatcher.cs
+++ b/Source/CrossPlatformArcadiaWatcher.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Threading;
@@ -6,104 +7,100 @@ using Godot;
 
 public class CrossPlatformArcadiaWatcher
 {
-    // Polls the FS
-    private System.Threading.Timer poll_timer;
-
-    // Reloads files
-    private System.Threading.Timer drain_timer;
-
-    private Dictionary<string, bool> changed_files = new Dictionary<string, bool>();
-    private Dictionary<string, FileInfo> last_files;
-
-    private bool verbose_logging = false;
+    private static readonly object reload_lock = new object();
+    private Dictionary<string, bool> file_busy = new Dictionary<string, bool>();
+    private FileSystemWatcher watcher;
 
     public CrossPlatformArcadiaWatcher(bool verbose)
     {
-        this.verbose_logging = verbose;
-        poll_timer = new System.Threading.Timer(CheckStatus, new AutoResetEvent(false), 100, 100);
-        drain_timer = new System.Threading.Timer(DrainChanges, new AutoResetEvent(false), 100, 100);
-    }
-
-    private void CheckStatus(System.Object stateInfo)
-    {
         var path = ProjectSettings.GlobalizePath("res://");
-        if (verbose_logging) { GD.Print($"Polling clj files in {path}..."); }
-        var di = new DirectoryInfo(path);
-        var files = di.GetFiles("*.clj?", SearchOption.AllDirectories);
+        var watcher = new FileSystemWatcher(path);
 
-        // First time checking, nothing to compare against.
-        var lookup = new Dictionary<string, FileInfo>();
-        foreach (var fi in files)
-        {
-            var name = fi.FullName.Replace(path, "");
-            if (verbose_logging) { GD.Print("Scanning " + name); }
-            lookup.Add(name, fi);
-        }
+        this.watcher = watcher;
 
-        if (last_files != null)
-        {
-            foreach (var kv in lookup)
-            {
-                var name = kv.Key;
-                var fi = kv.Value;
+        watcher.NotifyFilter = NotifyFilters.CreationTime
+            | NotifyFilters.DirectoryName
+            | NotifyFilters.FileName
+            | NotifyFilters.LastWrite
+            | NotifyFilters.Size;
 
-                if (last_files.ContainsKey(name))
-                {
-                    var changed = fi.LastWriteTime != last_files[name].LastWriteTime;
-                    if (changed)
-                    {
-                        OnChanged(name);
-                    }
-                }
-            }
-        }
+        watcher.Changed += OnChanged;
+        watcher.Created += OnCreated;
 
-        last_files = lookup;
+        watcher.Filter = "*.clj";
+        watcher.IncludeSubdirectories = true;
+        watcher.EnableRaisingEvents = true;
     }
 
-    private void OnChanged(string fileName)
+    static string ToRelativePath(FileSystemEventArgs ea){
+        var path = ProjectSettings.GlobalizePath("res://");
+        return ea.FullPath.Replace(path, "");
+    }
+
+    private void ReadFileTimeout(string RelativePath){
+        // We use `file_busy[RelativePath]` variable to deterime if a file is
+        // being reloaded. We add a short delay setting it back to `false` in
+        // order to prevent any duplicate reloads, since
+        // `Arcadia.Util.Invoke(ReplVar, RelativePath)` seems to trigger
+        // `Changed` events.
+        System.Threading.Timer timer = null;
+        timer = new System.Threading.Timer((obj) =>
+        {
+            file_busy[RelativePath] = false;
+            timer.Dispose();
+        },
+            null, 50, System.Threading.Timeout.Infinite);
+    }
+
+    private void reload(string RelativePath){
+        GD.Print("reloading ", RelativePath);
+        file_busy[RelativePath] = true;
+        var ReplVar = RT.var("arcadia.repl", "main-thread-load-path");
+        Arcadia.Util.Invoke(ReplVar, RelativePath);
+        this.ReadFileTimeout(RelativePath);
+    }
+
+    private void OnChanged(object sender, FileSystemEventArgs ea)
     {
-        GD.Print("Detected change in file " + fileName);
         try
         {
-            lock (changed_files)
+            lock (reload_lock)
             {
-                changed_files[fileName] = true;
-            }
-        }
-        catch (System.Exception err)
-        {
-            GD.PrintErr(err);
-        }
-        finally
-        {
+                var RelativePath = ToRelativePath(ea);
 
+                // FileSystemWatcher considers all files initially found as "Changed".
+                // That's why we skip them if they aren't in `file_busy`.
+                if (!file_busy.ContainsKey(RelativePath)){
+                    file_busy[RelativePath] = false;
+                    return;
+                }
+
+                if(file_busy[RelativePath]){
+                    return;
+                }
+
+                this.reload(RelativePath);
+            }
+
+        }
+        catch (System.Exception e)
+        {
+            GD.PrintErr(e);
         }
     }
 
-    private void DrainChanges(System.Object stateInfo)
+    private void OnCreated(object sender, FileSystemEventArgs ea)
     {
-        lock (changed_files)
+
+        try
         {
-            foreach (var path in changed_files.Keys)
-            {
-
-                if (path != null)
-                {
-                    GD.Print("reloading ", path);
-                    try
-                    {
-                        Arcadia.Util.Invoke(RT.var("arcadia.repl", "main-thread-load-path"), path);
-                    }
-                    catch (System.Exception e)
-                    {
-                        GD.PrintErr(e);
-                    }
-
-                }
-
-            }
-            changed_files.Clear();
+            var RelativePath = ToRelativePath(ea);
+            file_busy[RelativePath] = true;
+            this.reload(RelativePath);
+        }
+        catch
+        {
+            GD.PrintErr(e);
         }
     }
 }

--- a/Source/CrossPlatformArcadiaWatcher.cs
+++ b/Source/CrossPlatformArcadiaWatcher.cs
@@ -11,7 +11,7 @@ public class CrossPlatformArcadiaWatcher
     private Dictionary<string, bool> file_busy = new Dictionary<string, bool>();
     private FileSystemWatcher watcher;
 
-    public CrossPlatformArcadiaWatcher(bool verbose)
+    public CrossPlatformArcadiaWatcher()
     {
         var path = ProjectSettings.GlobalizePath("res://");
         var watcher = new FileSystemWatcher(path);
@@ -98,7 +98,7 @@ public class CrossPlatformArcadiaWatcher
             file_busy[RelativePath] = true;
             this.reload(RelativePath);
         }
-        catch
+        catch (System.Exception e)
         {
             GD.PrintErr(e);
         }

--- a/Source/MacOSArcadiaWatcher.cs
+++ b/Source/MacOSArcadiaWatcher.cs
@@ -1,0 +1,109 @@
+using System.IO;
+using System.Collections.Generic;
+using System.Threading;
+using clojure.lang;
+using Godot;
+
+public class MacOSArcadiaWatcher
+{
+    // Polls the FS
+    private System.Threading.Timer poll_timer;
+
+    // Reloads files
+    private System.Threading.Timer drain_timer;
+
+    private Dictionary<string, bool> changed_files = new Dictionary<string, bool>();
+    private Dictionary<string, FileInfo> last_files;
+
+    private bool verbose_logging = false;
+
+    public MacOSArcadiaWatcher(bool verbose)
+    {
+        this.verbose_logging = verbose;
+        poll_timer = new System.Threading.Timer(CheckStatus, new AutoResetEvent(false), 100, 100);
+        drain_timer = new System.Threading.Timer(DrainChanges, new AutoResetEvent(false), 100, 100);
+    }
+
+    private void CheckStatus(System.Object stateInfo)
+    {
+        var path = ProjectSettings.GlobalizePath("res://");
+        if (verbose_logging) { GD.Print($"Polling clj files in {path}..."); }
+        var di = new DirectoryInfo(path);
+        var files = di.GetFiles("*.clj?", SearchOption.AllDirectories);
+
+        // First time checking, nothing to compare against.
+        var lookup = new Dictionary<string, FileInfo>();
+        foreach (var fi in files)
+        {
+            var name = fi.FullName.Replace(path, "");
+            if (verbose_logging) { GD.Print("Scanning " + name); }
+            lookup.Add(name, fi);
+        }
+
+        if (last_files != null)
+        {
+            foreach (var kv in lookup)
+            {
+                var name = kv.Key;
+                var fi = kv.Value;
+
+                if (last_files.ContainsKey(name))
+                {
+                    var changed = fi.LastWriteTime != last_files[name].LastWriteTime;
+                    if (changed)
+                    {
+                        OnChanged(name);
+                    }
+                }
+            }
+        }
+
+        last_files = lookup;
+    }
+
+    private void OnChanged(string fileName)
+    {
+        GD.Print("Detected change in file " + fileName);
+        try
+        {
+            lock (changed_files)
+            {
+                changed_files[fileName] = true;
+            }
+        }
+        catch (System.Exception err)
+        {
+            GD.PrintErr(err);
+        }
+        finally
+        {
+
+        }
+    }
+
+    private void DrainChanges(System.Object stateInfo)
+    {
+        lock (changed_files)
+        {
+            foreach (var path in changed_files.Keys)
+            {
+
+                if (path != null)
+                {
+                    GD.Print("reloading ", path);
+                    try
+                    {
+                        Arcadia.Util.Invoke(RT.var("arcadia.repl", "main-thread-load-path"), path);
+                    }
+                    catch (System.Exception e)
+                    {
+                        GD.PrintErr(e);
+                    }
+
+                }
+
+            }
+            changed_files.Clear();
+        }
+    }
+}


### PR DESCRIPTION
Currently the watcher uses quite a bit of CPU power to run (htop was showing me 15%~ CPU when idle). This is due to there being two polling actions. To fix this I implemented a `FileSystemWatcher` instead of polling which can be used by Windows / Linux. I moved the old watcher to `MacOSArcadiaWatcher` so that can be used by MacOS users.

I'm learning C# as I go so surely things can be improved.