### PR TITLE
Implement automatic hook attachment through function metadata

### DIFF
--- a/ArcadiaHook.cs
+++ b/ArcadiaHook.cs
@@ -50,6 +50,7 @@ namespace Arcadia
                 SetClojureLoadPathWithDLLs();
                 RT.load("clojure/core");
                 RT.load("arcadia/internal/namespace");
+                RT.load("arcadia/internal/hook");
                 if (OS.IsDebugBuild()) {
                     RT.load("arcadia/repl");
                     Util.Invoke(RT.var("arcadia.repl", "launch"), null);
@@ -225,7 +226,7 @@ namespace Arcadia
                 catch (Exception err)
                 {
                     GD.PrintErr(err);
-                }     
+                }
             }
         }
 

--- a/ArcadiaHook.tscn
+++ b/ArcadiaHook.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://ArcadiaGodot/ArcadiaHook.cs" type="Script" id=1]
+
+[node name="ArcadiaHook" type="Node"]
+script = ExtResource( 1 )

--- a/Source/Util.cs
+++ b/Source/Util.cs
@@ -1,3 +1,4 @@
+using Godot;
 using System;
 using clojure.lang;
 using System.Collections.Generic;
@@ -6,6 +7,9 @@ namespace Arcadia
 {
 	public class Util
 	{
+            public static ResourceSaver.SaverFlags FLAG_RELATIVE_PATHS (){
+                return (ResourceSaver.SaverFlags) 1;
+            }
 
 		public static ArcadiaHook GetHook(Godot.Node o){
 			for (int i = 0; i < o.GetChildCount(); i++)

--- a/Source/arcadia/internal/hook.clj
+++ b/Source/arcadia/internal/hook.clj
@@ -3,10 +3,9 @@
    [clojure.edn :as edn])
   (:use arcadia.core))
 
-(defn- arcadia-hook-instance []
+(defn- arcadia-hook-packed-scene []
   (-> "res://ArcadiaGodot/ArcadiaHook.tscn"
-      (Godot.ResourceLoader/Load "PackedScene" true)
-      (.Instance 0)))
+      (Godot.ResourceLoader/Load "PackedScene" false)))
 
 (defn- get-arcadia-hook [node]
   (->> node
@@ -36,11 +35,12 @@
   (set! (.-unhandled_input_fn node) (get hooks :hook/unhandled-input "")))
 
 (defn add-hook-script! [scene hooks]
-  (when-not (Godot.ResourceLoader/Load scene "PackedScene" true)
+  (when-not (Godot.ResourceLoader/Load scene "PackedScene" false)
     (throw (ex-info (str "Resource " scene " not found while trying to apply hooks") {:scene scene :hooks hooks})))
-  (let [resource (Godot.ResourceLoader/Load scene "PackedScene" true)
+  (let [resource (Godot.ResourceLoader/Load scene "PackedScene" false)
         resource-instance (.Instance resource 0)
-        arcadia-hook (arcadia-hook-instance)
+        packed-scene (arcadia-hook-packed-scene)
+        arcadia-hook (.Instance packed-scene 0)
         packed-scene (Godot.PackedScene.)]
     (when-not (equal-hooks? (get-arcadia-hook resource-instance) hooks)
       (when-let [arcadia-hook (get-arcadia-hook resource-instance)]

--- a/Source/arcadia/internal/hook.clj
+++ b/Source/arcadia/internal/hook.clj
@@ -1,0 +1,87 @@
+(ns arcadia.internal.hook
+  (:require
+   [clojure.edn :as edn])
+  (:use arcadia.core))
+
+(defn- arcadia-hook-instance []
+  (-> "res://ArcadiaGodot/ArcadiaHook.tscn"
+      (Godot.ResourceLoader/Load "PackedScene" true)
+      (.Instance 0)))
+
+(defn- get-arcadia-hook [node]
+  (->> node
+       (arcadia.core/children)
+       (filter (fn [n] (#{"ArcadiaHook"} (.Name n))))
+       (first)))
+
+(defn equal-hooks? [arcadia-hook hooks]
+  (and arcadia-hook
+       (= (.-ready_fn arcadia-hook) (get hooks :hook/ready ""))
+       (= (.-tree_ready_fn arcadia-hook) (get hooks :hook/tree-ready ""))
+       (= (.-enter_tree_fn arcadia-hook) (get hooks :hook/enter-tree ""))
+       (= (.-exit_tree_fn arcadia-hook) (get hooks :hook/exit-tree ""))
+       (= (.-process_fn arcadia-hook) (get hooks :hook/process ""))
+       (= (.-physics_process_fn arcadia-hook) (get hooks :hook/physics-process ""))
+       (= (.-input_fn arcadia-hook) (get hooks :hook/input ""))
+       (= (.-unhandled_input_fn arcadia-hook) (get hooks :hook/unhandled-input ""))))
+
+(defn set-hooks! [node hooks]
+  (set! (.-ready_fn node) (get hooks :hook/ready ""))
+  (set! (.-tree_ready_fn node) (get hooks :hook/tree-ready ""))
+  (set! (.-enter_tree_fn node) (get hooks :hook/enter-tree ""))
+  (set! (.-exit_tree_fn node) (get hooks :hook/exit-tree ""))
+  (set! (.-process_fn node) (get hooks :hook/process ""))
+  (set! (.-physics_process_fn node) (get hooks :hook/physics-process ""))
+  (set! (.-input_fn node) (get hooks :hook/input ""))
+  (set! (.-unhandled_input_fn node) (get hooks :hook/unhandled-input "")))
+
+(defn add-hook-script! [scene hooks]
+  (when-not (Godot.ResourceLoader/Load scene "PackedScene" true)
+    (throw (ex-info (str "Resource " scene " not found while trying to apply hooks") {:scene scene :hooks hooks})))
+  (let [resource (Godot.ResourceLoader/Load scene "PackedScene" true)
+        resource-instance (.Instance resource 0)
+        arcadia-hook (arcadia-hook-instance)
+        packed-scene (Godot.PackedScene.)]
+    (when-not (equal-hooks? (get-arcadia-hook resource-instance) hooks)
+      (when-let [arcadia-hook (get-arcadia-hook resource-instance)]
+        (.RemoveChild resource-instance arcadia-hook))
+      (set-hooks! arcadia-hook hooks)
+      (.AddChild resource-instance arcadia-hook  false)
+      (set! (.-Owner arcadia-hook) resource-instance)
+      (.Pack packed-scene resource-instance)
+      (Godot.ResourceSaver/Save scene packed-scene (Arcadia.Util/FLAG_RELATIVE_PATHS)))))
+
+(def hook-keys
+  #{:hook/ready
+    :hook/tree-ready
+    :hook/enter-tree
+    :hook/exit-tree
+    :hook/process
+    :hook/physics-process
+    :hook/input
+    :hook/unhandled-input})
+
+(defn hooks-from-file [file]
+  (for [[_ v] (-> file slurp edn/read-string second ns-publics)
+        [mk mv] (meta v)
+        :when (hook-keys mk)]
+    {:hook/key mk
+     :hook/fn (str v)
+     :hook/scenes mv}))
+
+(defn hooks-per-scene [hooks]
+  (->> hooks (mapv :hook/scenes) flatten set
+       (mapv (fn [scene]
+               {scene
+                (mapv
+                 (fn [hook] {(:hook/key hook)
+                             (:hook/fn hook)})
+                 (filter (fn [hook]
+                           ((set (flatten (:hook/scenes hook))) scene)) hooks))}))
+       (into {})
+       (mapv (fn [[k v]] [k (apply merge v)]) )
+       (into {})))
+
+(defn reload [file]
+  (doseq [[scene hooks] (hooks-per-scene (hooks-from-file file))]
+    (add-hook-script! scene hooks)))

--- a/Source/arcadia/repl.clj
+++ b/Source/arcadia/repl.clj
@@ -297,8 +297,8 @@
 
 (defn load-all-clj-files []
   (let [files
-        (->> (:source-paths arcadia.internal.config/config "src")
-             (mapcat #(System.IO.Directory/GetFiles %, "*.clj", SearchOption/AllDirectories))
+        (->> (:source-paths arcadia.internal.config/config ["src"])
+             (mapcat #(System.IO.Directory/GetFiles % "*.clj" SearchOption/AllDirectories))
              (set))]
     (doseq [file files]
       (try


### PR DESCRIPTION
Fixes https://github.com/arcadia-unity/ArcadiaGodot/issues/23

This PR implements a method of automatically attaching hooks to scenes. It does it in the follow way:

1. Add metadata to your function is the form: 
``` clojure
(defn ^:{:hook/ready ["res://Scene/Main.tscn"]} ready [self _] ,,,)
```

2. During startup we search for all clj files in `:source-paths` and process these in arcadia/internal/hook.clj.
3. Load these files, get all their functions + metadata and filter any `:hook/*` keys.
4. Generate a new ArcadiaHook node (through ArcadiaHook.tscn) and attach any hook to keys this.
5. Attach the new ArcadiaHook node to the scene specified in the metadata, if the hooks did not change, skip this step.
6. Do these steps for each file separately when the specific file changes (with the ArcadiaWatcher)

What do you think of this strategy? Being able to attach hooks through clojure code is a much better experience IMHO rather than manually adding the node + hooks. This is also an opt-in method so you could also choose the manual route if you want to.